### PR TITLE
Remove latitude, longitude and zoom from Country

### DIFF
--- a/src/main/java/org/worldcubeassociation/db/Country.java
+++ b/src/main/java/org/worldcubeassociation/db/Country.java
@@ -8,18 +8,12 @@ public class Country {
     private final String fId;
     private final String fName;
     private final String fContinentId;
-    private final String fLatitude;
-    private final String fLongitude;
-    private final String fZoom;
     private final String fIso2;
 
-    public Country(String aId, String aName, String aContinentId, String aLatitude, String aLongitude, String aZoom, String aIso2) {
+    public Country(String aId, String aName, String aContinentId, String aIso2) {
         fId = aId;
         fName = aName;
         fContinentId = aContinentId;
-        fLatitude = aLatitude;
-        fLongitude = aLongitude;
-        fZoom = aZoom;
         fIso2 = aIso2;
     }
 
@@ -33,18 +27,6 @@ public class Country {
 
     public String getContinentId() {
         return fContinentId;
-    }
-
-    public String getLatitude() {
-        return fLatitude;
-    }
-
-    public String getLongitude() {
-        return fLongitude;
-    }
-
-    public String getZoom() {
-        return fZoom;
     }
 
     public String getIso2() {

--- a/src/main/java/org/worldcubeassociation/db/WCADatabaseExportDecoder.java
+++ b/src/main/java/org/worldcubeassociation/db/WCADatabaseExportDecoder.java
@@ -137,12 +137,9 @@ public class WCADatabaseExportDecoder {
             String id = scanner.next();
             String name = scanner.next();
             String continentId = scanner.next();
-            String latitude = scanner.next();
-            String longitude = scanner.next();
-            String zoom = scanner.next();
             String iso2 = scanner.next();
 
-            Country country = new Country(id, name, continentId, latitude, longitude, zoom, iso2);
+            Country country = new Country(id, name, continentId, iso2);
             countries.add(country);
         }
 


### PR DESCRIPTION
Fixes #114.
I haven't been contributing here before but I hope I've done things right.
These are all the places using `longitude`, `latitude` and `zoom` related to Country.
